### PR TITLE
hotfix: versioning for pkg will skip if already set [skip ci]

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -97,4 +97,12 @@ jobs:
       - name: Publish to GitHub Packages
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm publish
+          PACKAGE_VERSION: ${{ needs.updates_version.outputs.package_version }}
+        run: |
+          set -euo pipefail
+          if npm view "@matech-studios/fe-react-lib@${PACKAGE_VERSION}" version --registry https://npm.pkg.github.com > /dev/null 2>&1; then
+            echo "Version ${PACKAGE_VERSION} already published to GitHub Packages; skipping."
+            exit 0
+          fi
+          npm publish
+


### PR DESCRIPTION
## 🔗 Link to Jira User Story
<img width="498" height="281" alt="image" src="https://c.tenor.com/qG7PGA4wC10AAAAd/tenor.gif" />

## 📖 Story Description
<!-- Brief description of the functionality implemented or the problem fixed. -->

## 🚨 Type of Changes
<!-- Mark with an 'X' in the applicable options. -->
- [ ] ➕ New feature
- [X] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [X] 💅 Improvement

## ✅ PR Checklist
<!-- Review and mark with an 'X' each of the following items. -->
- [ ] Updated unit tests
- [n/a] Updated documentation
- [ ] Locally tested changes
- [ ] Complies with code style guidelines

## 🔍 Tests Performed
<!-- Describe the tests you performed to verify your changes. Include relevant details to help reviewers. -->

## 🖼 Screenshots (if applicable)
<!-- Include screenshots of the new functionalities or visual changes. -->

## 📝 Additional Notes
<!-- Any additional information you consider important to share -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now skips redundant package version updates when the computed version matches the current one, reducing pointless commits and release noise.
  * Publishing step now detects existing package versions and skips re-publishing duplicates, avoiding unnecessary publish attempts.
  * No user-facing changes; app behavior and features remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->